### PR TITLE
Added in multiprocessing function with schwimmbad

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python package
+name: Test LEGWORK
 
 on:
   push:

--- a/legwork/evol.py
+++ b/legwork/evol.py
@@ -309,13 +309,16 @@ def evol_ecc(ecc_i, t_evol=None, n_step=100, timesteps=None, beta=None,
     beta = beta.to(u.m**4 / u.s).value
     timesteps = timesteps.to(u.s).value
 
-    def integrate_de_dt(args):                                 # pragma: no cover
-        ecc_i, timesteps, beta, c_0 = args
-        e = odeint(de_dt, ecc_i, timesteps,
-                   args=(beta, c_0)).flatten()
-    
     # perform the evolution
     if n_proc > 1:
+        def integrate_de_dt(args):                             # pragma: no cover
+            ecc_i, timesteps, beta, c_0 = args
+            e = odeint(de_dt, ecc_i, timesteps,
+                       args=(beta, c_0)).flatten()
+
+            return e
+
+
         with MultiPool(processes=n_proc) as pool:
             ecc_evol = np.array(list(pool.map(integrate_de_dt,
                                               zip(ecc_i,

--- a/legwork/evol.py
+++ b/legwork/evol.py
@@ -9,7 +9,7 @@ import astropy.units as u
 import astropy.constants as c
 from schwimmbad import MultiPool
 
-__all__ = ['de_dt', 'evol_circ', 'evol_ecc',
+__all__ = ['de_dt', 'evol_circ', 'integrate_de_dt', 'evol_ecc',
            'get_t_merge_circ', 'get_t_merge_ecc', 'evolve_f_orb_circ',
            'check_mass_freq_input', 'create_timesteps_array', ]
 

--- a/legwork/evol.py
+++ b/legwork/evol.py
@@ -9,7 +9,7 @@ import astropy.units as u
 import astropy.constants as c
 from schwimmbad import MultiPool
 
-__all__ = ['de_dt', 'evol_circ', 'integrate_de_dt', 'evol_ecc',
+__all__ = ['de_dt', 'evol_circ', 'evol_ecc',
            'get_t_merge_circ', 'get_t_merge_ecc', 'evolve_f_orb_circ',
            'check_mass_freq_input', 'create_timesteps_array', ]
 
@@ -230,36 +230,6 @@ def evol_circ(t_evol=None, n_step=100, timesteps=None, beta=None, m_1=None,
     return evolution if len(evolution) > 1 else evolution[0]
 
 
-def integrate_de_dt(args):
-    """Function that integrates de_dt with odeint
-
-    Parameters
-    ----------
-    ecc_i : `float`
-        Initial eccentricity
-
-    timesteps : `array`
-        Array of exact timesteps to take when evolving each binary. Must be
-        monotonically increasing and start with t=0.
-
-    beta : `float`
-        beta(m_1, m_2) from Peters 1964 Eq. 5.9
-
-    c_0 : `float`
-        factor defined in Peters 1964
-
-
-    Outputs
-    -------
-    e : `array`
-       eccentricity evolution
-    """
-    ecc_i, timesteps, beta, c_0 = args
-    e = odeint(de_dt, ecc_i, timesteps,
-               args=(beta, c_0)).flatten()
-    return e
-
-
 def evol_ecc(ecc_i, t_evol=None, n_step=100, timesteps=None, beta=None,
              m_1=None, m_2=None, a_i=None, f_orb_i=None,
              output_vars=['ecc', 'f_orb'], n_proc=1):
@@ -339,6 +309,11 @@ def evol_ecc(ecc_i, t_evol=None, n_step=100, timesteps=None, beta=None,
     beta = beta.to(u.m**4 / u.s).value
     timesteps = timesteps.to(u.s).value
 
+    def integrate_de_dt(args):                                 # pragma: no cover
+        ecc_i, timesteps, beta, c_0 = args
+        e = odeint(de_dt, ecc_i, timesteps,
+                   args=(beta, c_0)).flatten()
+    
     # perform the evolution
     if n_proc > 1:
         with MultiPool(processes=n_proc) as pool:

--- a/legwork/evol.py
+++ b/legwork/evol.py
@@ -230,7 +230,7 @@ def evol_circ(t_evol=None, n_step=100, timesteps=None, beta=None, m_1=None,
     return evolution if len(evolution) > 1 else evolution[0]
 
 
-def integrate_de_dt(args):
+def integrate_de_dt(args):                                 # pragma: no cover
     """Function that integrates de_dt with odeint
     Parameters
     ----------

--- a/legwork/snr.py
+++ b/legwork/snr.py
@@ -210,7 +210,7 @@ def snr_circ_evolving(m_1, m_2, f_orb_i, dist, t_obs, n_step,
 
 
 def snr_ecc_evolving(m_1, m_2, f_orb_i, dist, ecc, max_harmonic, t_obs, n_step,
-                     interpolated_g=None, interpolated_sc=None):
+                     interpolated_g=None, interpolated_sc=None, n_proc=1):
     """Computes SNR for eccentric and evolving sources.
 
     Note that this function will not work for exactly circular (ecc = 0.0)
@@ -255,6 +255,10 @@ def snr_ecc_evolving(m_1, m_2, f_orb_i, dist, ecc, max_harmonic, t_obs, n_step,
         take care to ensure that your interpolated function has the same LISA
         observation time as ``t_obs``.
 
+    n_proc : `int`
+        Number of processors to split eccentricity evolution over, where
+        the default is n_proc=1
+
     Returns
     -------
     snr : `array`
@@ -268,7 +272,7 @@ def snr_ecc_evolving(m_1, m_2, f_orb_i, dist, ecc, max_harmonic, t_obs, n_step,
 
     # get eccentricity and f_orb evolutions
     e_evol, f_orb_evol = evol.evol_ecc(ecc_i=ecc, t_evol=t_evol, n_step=n_step,
-                                       m_1=m_1, m_2=m_2, f_orb_i=f_orb_i)
+                                       m_1=m_1, m_2=m_2, f_orb_i=f_orb_i, n_proc=n_proc)
 
     # create harmonics list and multiply for nth frequency evolution
     harms = np.arange(1, max_harmonic + 1).astype(int)

--- a/legwork/source.py
+++ b/legwork/source.py
@@ -87,7 +87,7 @@ class Source():
     AssertionError
         If a parameter is missing units
     """
-    def __init__(self, m_1, m_2, ecc, dist, n_proc=None, f_orb=None, a=None,
+    def __init__(self, m_1, m_2, ecc, dist, n_proc=1, f_orb=None, a=None,
                  gw_lum_tol=0.05, stat_tol=1e-2, interpolate_g=True,
                  interpolate_sc=True, sc_params={}):
         # ensure that either a frequency or semi-major axis is supplied
@@ -127,10 +127,6 @@ class Source():
 
         # reset the arguments with the new converted ones
         m_1, m_2, dist, f_orb, a, ecc = array_args
-
-        # if n_proc not specified, set n_proc=1
-        if n_proc is None:
-            n_proc = 1
 
         self.m_1 = m_1
         self.m_2 = m_2

--- a/legwork/source.py
+++ b/legwork/source.py
@@ -87,7 +87,7 @@ class Source():
     AssertionError
         If a parameter is missing units
     """
-    def __init__(self, m_1, m_2, ecc, dist, n_proc, f_orb=None, a=None,
+    def __init__(self, m_1, m_2, ecc, dist, n_proc=None, f_orb=None, a=None,
                  gw_lum_tol=0.05, stat_tol=1e-2, interpolate_g=True,
                  interpolate_sc=True, sc_params={}):
         # ensure that either a frequency or semi-major axis is supplied
@@ -127,6 +127,10 @@ class Source():
 
         # reset the arguments with the new converted ones
         m_1, m_2, dist, f_orb, a, ecc = array_args
+
+        # if n_proc not specified, set n_proc=1
+        if n_proc is None:
+            n_proc = 1
 
         self.m_1 = m_1
         self.m_2 = m_2

--- a/legwork/source.py
+++ b/legwork/source.py
@@ -32,6 +32,9 @@ class Source():
     dist : `float/array`
         luminosity distance to source. Must have astropy units of distance.
 
+    n_proc : `int`
+        number of processors to split eccentric evolution over if needed
+
     f_orb : `float/array`
         orbital frequency (either `a` or `f_orb` must be supplied)
         This takes precedence over `a`. Must have astropy units of frequency.
@@ -84,7 +87,7 @@ class Source():
     AssertionError
         If a parameter is missing units
     """
-    def __init__(self, m_1, m_2, ecc, dist, f_orb=None, a=None,
+    def __init__(self, m_1, m_2, ecc, dist, n_proc, f_orb=None, a=None,
                  gw_lum_tol=0.05, stat_tol=1e-2, interpolate_g=True,
                  interpolate_sc=True, sc_params={}):
         # ensure that either a frequency or semi-major axis is supplied
@@ -133,6 +136,7 @@ class Source():
         self.stat_tol = stat_tol
         self.f_orb = f_orb
         self.a = a
+        self.n_proc = n_proc
         self.snr = None
         self.n_sources = len(m_1)
         self.interpolate_sc = interpolate_sc
@@ -558,7 +562,8 @@ class Source():
                                                      t_obs=t_obs,
                                                      n_step=n_step,
                                                      interpolated_g=self.g,
-                                                     interpolated_sc=self.sc)
+                                                     interpolated_sc=self.sc,
+                                                     n_proc=self.n_proc)
 
         return snr[which_sources]
 

--- a/legwork/tests/test_sources.py
+++ b/legwork/tests/test_sources.py
@@ -49,10 +49,8 @@ class Test(unittest.TestCase):
 
         # create random (circular/stationary) binaries
         n_values = 500
-        t_obs = 4 * u.yr
         m_1 = np.random.uniform(0, 10, n_values) * u.Msun
         m_2 = np.random.uniform(0, 10, n_values) * u.Msun
-        m_c = utils.chirp_mass(m_1, m_2)
         dist = np.random.uniform(0, 30, n_values) * u.kpc
         f_orb = 10**(np.random.uniform(-3, -2, n_values)) * u.Hz
         ecc = np.random.uniform(0.1, 0.2, n_values)
@@ -61,7 +59,7 @@ class Test(unittest.TestCase):
                                 ecc=ecc, dist=dist, n_proc=n_proc)
 
         sources_1 = source.Source(m_1=m_1, m_2=m_2, f_orb=f_orb,
-                                ecc=ecc, dist=dist, n_proc=1) 
+                                  ecc=ecc, dist=dist, n_proc=1) 
         
         # compare using 1 or 2 processors
         snr_2 = sources.get_snr(verbose=True)

--- a/legwork/tests/test_sources.py
+++ b/legwork/tests/test_sources.py
@@ -54,29 +54,20 @@ class Test(unittest.TestCase):
         m_2 = np.random.uniform(0, 10, n_values) * u.Msun
         m_c = utils.chirp_mass(m_1, m_2)
         dist = np.random.uniform(0, 30, n_values) * u.kpc
-        f_orb = 10**(np.random.uniform(-5, -4, n_values)) * u.Hz
-        ecc = np.repeat(0.0, n_values)
+        f_orb = 10**(np.random.uniform(-3, -2, n_values)) * u.Hz
+        ecc = np.random.uniform(0.1, 0.2, n_values)
         n_proc = 2
         sources = source.Source(m_1=m_1, m_2=m_2, f_orb=f_orb,
                                 ecc=ecc, dist=dist, n_proc=n_proc)
 
-        # compare snr calculated directly with through Source
-        snr_direct = snr.snr_circ_stationary(m_c=m_c, f_orb=f_orb,
-                                             dist=dist, t_obs=t_obs)
-        snr_source = sources.get_snr(verbose=True)
+        sources_1 = source.Source(m_1=m_1, m_2=m_2, f_orb=f_orb,
+                                ecc=ecc, dist=dist, n_proc=1) 
+        
+        # compare using 1 or 2 processors
+        snr_2 = sources.get_snr(verbose=True)
+        snr_1 = sources_1.get_snr(verbose=True)
 
-        self.assertTrue(np.allclose(snr_direct, snr_source))
-
-        # repeat the same test for eccentric systems
-        ecc = np.random.uniform(sources.ecc_tol, 0.1, n_values)
-        sources.ecc = ecc
-
-        snr_direct = snr.snr_ecc_stationary(m_c=m_c, f_orb=f_orb, ecc=ecc,
-                                            dist=dist, t_obs=t_obs,
-                                            max_harmonic=10)
-        snr_source = sources.get_snr(verbose=True)
-
-        self.assertTrue(np.allclose(snr_direct, snr_source))
+        self.assertTrue(np.allclose(snr_2, snr_1))
 
     def test_source_strain(self):
         """check that source calculate strain correctly"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ numba >= 0.50'
 scipy >= 1.5.0'
 matplotlib >= 3.3.2'
 seaborn >= 0.11.1'
+schwimmbad


### PR DESCRIPTION
When running a simple script with the following number of sources:
	6742 sources are stationary
		6742 sources are stationary and eccentric
	93258 sources are evolving
		93258 sources are evolving and eccentric

nproc: 1, time: 309.5520007610321
nproc: 20, time: 149.16188645362854

