### PR TITLE
Implement evolution of sources directly from class

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,16 @@
+# LEGWORK Changelog
+This log keeps track of the changes implemented in each version of LEGWORK.
+
+## 0.0.1
+- Initial release
+
+## 0.0.2
+- Update version number to work with pip
+
+## 0.0.3
+*TW, 12/04/21*
+- Allow the computation of merger times with ``get_merger_times``
+    - After computing, times are used automatically
+    in subsequent SNR calculations to avoid doubling up the computation
+- Add ``evolve_sources`` function that evolves sources through time, updates merger times and if necessary marks them as merged
+    - Merged sources are ignored in other computations (e.g. strain and SNR)

--- a/changelog.md
+++ b/changelog.md
@@ -15,3 +15,4 @@ This log keeps track of the changes implemented in each version of LEGWORK.
 - Add ``evolve_sources`` function that evolves sources through time, updates merger times and if necessary marks them as merged
     - Merged sources are ignored in other computations (e.g. strain and SNR)
 - Add ``ret_snr2_by_harmonic`` to eccentric snr functions to allow the user to get the SNR at each harmonic separately instead of the total
+- Add minor fixes to snr for evolving sources for when sources are closes to merging

--- a/changelog.md
+++ b/changelog.md
@@ -14,3 +14,4 @@ This log keeps track of the changes implemented in each version of LEGWORK.
     in subsequent SNR calculations to avoid doubling up the computation
 - Add ``evolve_sources`` function that evolves sources through time, updates merger times and if necessary marks them as merged
     - Merged sources are ignored in other computations (e.g. strain and SNR)
+- Add ``ret_snr2_by_harmonic`` to eccentric snr functions to allow the user to get the SNR at each harmonic separately instead of the total

--- a/legwork/evol.py
+++ b/legwork/evol.py
@@ -266,7 +266,7 @@ def evol_circ(t_evol=None, n_step=100, timesteps=None, beta=None, m_1=None,
                                             m_2=m_2[:, np.newaxis])
 
         # change frequencies back to 1Hz since LISA can't measure above
-        f_orb_evol = np.where(a_not0.value == 1e-30, 1 * u.Hz, f_orb_evol)
+        f_orb_evol = np.where(a_not0.value == 1e-30, 1e2* u.Hz, f_orb_evol)
 
     # construct evolution output
     evolution = []
@@ -405,7 +405,7 @@ def evol_ecc(ecc_i, t_evol=None, n_step=100, timesteps=None, beta=None,
                                                 m_2=m_2[:, np.newaxis])
 
             # change frequencies back to 1Hz since LISA can't measure above
-            f_orb_evol = np.where(a_not0.value == 1e-30, 1 * u.Hz, f_orb_evol)
+            f_orb_evol = np.where(a_not0.value == 1e-30, 1e2* u.Hz, f_orb_evol)
 
     # construct evolution output
     evolution = []

--- a/legwork/psd.py
+++ b/legwork/psd.py
@@ -105,10 +105,9 @@ def lisa_psd(f, t_obs=4*u.yr, L=2.5e9, approximate_R=False,
     # minimum and maximum frequencies in Hz based on the R file from Robson+19
     MIN_F = 1e-7
     MAX_F = 2e0
-    HUGE_NOISE = 1e30
 
-    # overwrite frequencies that outside the range
-    f = np.where(np.logical_and(f > MIN_F, f < MAX_F), f, 1e-7)
+    # overwrite frequencies that outside the range to prevent error
+    f = np.where(np.logical_and(f >= MIN_F, f <= MAX_F), f, 1e-8)
 
     # single link optical metrology noise (Robson+ Eq. 10)
     def Poms(f):
@@ -154,7 +153,7 @@ def lisa_psd(f, t_obs=4*u.yr, L=2.5e9, approximate_R=False,
     psd = (1 / (L**2) * (Poms(f) + 4 * Pacc(f) / (2 * np.pi * f)**4)) / R + cn
 
     # replace values for bad frequencies (set to extremely high value)
-    psd = np.where(np.logical_and(f >= MIN_F, f <= MAX_F), psd, HUGE_NOISE)
+    psd = np.where(np.logical_and(f >= MIN_F, f <= MAX_F), psd, np.inf)
     return psd / u.Hz
 
 

--- a/legwork/snr.py
+++ b/legwork/snr.py
@@ -229,10 +229,11 @@ def snr_circ_evolving(m_1, m_2, f_orb_i, dist, t_obs, n_step, t_merge=None,
     m_c = utils.chirp_mass(m_1=m_1, m_2=m_2)
 
     # calculate minimum of observation time and merger time
-    t_merge = evol.get_t_merge_circ(m_1=m_1,
-                                    m_2=m_2,
-                                    f_orb_i=f_orb_i)
-    t_evol = np.minimum(t_merge, t_obs)
+    if t_merge is None:
+        t_merge = evol.get_t_merge_circ(m_1=m_1,
+                                        m_2=m_2,
+                                        f_orb_i=f_orb_i)
+    t_evol = np.minimum(t_merge - (1 * u.s), t_obs)
 
     # get f_orb evolution
     f_orb_evol = evol.evol_circ(t_evol=t_evol,

--- a/legwork/snr.py
+++ b/legwork/snr.py
@@ -73,8 +73,8 @@ def snr_circ_stationary(m_c, f_orb, dist, t_obs, interpolated_g=None,
 
 def snr_ecc_stationary(m_c, f_orb, ecc, dist, t_obs, harmonics_required,
                        interpolated_g=None, interpolated_sc=None,
-                       ret_max_snr_harmonic=False, instrument="LISA",
-                       custom_psd=None):
+                       ret_max_snr_harmonic=False, ret_snr2_by_harmonic=False,
+                       instrument="LISA", custom_psd=None):
     """Computes SNR for eccentric and stationary sources
 
     Parameters
@@ -113,6 +113,11 @@ def snr_ecc_stationary(m_c, f_orb, ecc, dist, t_obs, harmonics_required,
     ret_max_snr_harmonic : `boolean`
         Whether to return (in addition to the snr), the harmonic with the
         maximum SNR
+
+    ret_snr2_by_harmonic : `boolean`
+        Whether to return the SNR^2 in each individual harmonic rather than
+        the total. The total can be retrieving by summing and then taking
+        the square root.
 
     instrument : `{{ 'LISA', 'TianQin', 'custom' }}`
         Instrument to observe with. If 'custom' then ``custom_psd`` must be
@@ -154,6 +159,9 @@ def snr_ecc_stationary(m_c, f_orb, ecc, dist, t_obs, harmonics_required,
                                                   custom_function=custom_psd)
 
     snr_n_2 = (h_f_src_ecc_2 / h_f_lisa_n_2).decompose()
+
+    if ret_snr2_by_harmonic:
+        return snr_n_2
 
     if ret_max_snr_harmonic:
         max_snr_harmonic = np.argmax(snr_n_2, axis=1) + 1
@@ -260,7 +268,8 @@ def snr_circ_evolving(m_1, m_2, f_orb_i, dist, t_obs, n_step, t_merge=None,
 def snr_ecc_evolving(m_1, m_2, f_orb_i, dist, ecc, harmonics_required, t_obs,
                      n_step, t_merge=None, interpolated_g=None,
                      interpolated_sc=None, n_proc=1,
-                     ret_max_snr_harmonic=False, instrument="LISA",
+                     ret_max_snr_harmonic=False, ret_snr2_by_harmonic=False,
+                     instrument="LISA",
                      custom_psd=None):
     """Computes SNR for eccentric and evolving sources.
 
@@ -317,6 +326,11 @@ def snr_ecc_evolving(m_1, m_2, f_orb_i, dist, ecc, harmonics_required, t_obs,
         Whether to return (in addition to the snr), the harmonic with the
         maximum SNR
 
+    ret_snr2_by_harmonic : `boolean`
+        Whether to return the SNR^2 in each individual harmonic rather than
+        the total. The total can be retrieving by summing and then taking
+        the square root.
+
     instrument : `{{ 'LISA', 'TianQin', 'custom' }}`
         Instrument to observe with. If 'custom' then ``custom_psd`` must be
         supplied.
@@ -368,6 +382,9 @@ def snr_ecc_evolving(m_1, m_2, f_orb_i, dist, ecc, harmonics_required, t_obs,
 
     # integrate, sum and square root to get SNR
     snr_n_2 = np.trapz(y=h_c_n_2 / h_c_lisa_2, x=f_n_evol, axis=1)
+
+    if ret_snr2_by_harmonic:
+        return snr_n_2
 
     if ret_max_snr_harmonic:
         max_snr_harmonic = np.argmax(snr_n_2, axis=1) + 1

--- a/legwork/snr.py
+++ b/legwork/snr.py
@@ -1,10 +1,7 @@
 """Functions to calculate signal-to-noise ratio in four different cases"""
 
 import numpy as np
-import legwork.strain as strain
-import legwork.psd as psd
-import legwork.utils as utils
-import legwork.evol as evol
+from legwork import strain, psd, utils, evol
 import astropy.units as u
 
 __all__ = ['snr_circ_stationary', 'snr_ecc_stationary', 'snr_circ_evolving',

--- a/legwork/snr.py
+++ b/legwork/snr.py
@@ -167,7 +167,7 @@ def snr_ecc_stationary(m_c, f_orb, ecc, dist, t_obs, harmonics_required,
     return snr, max_snr_harmonic if ret_max_snr_harmonic else snr
 
 
-def snr_circ_evolving(m_1, m_2, f_orb_i, dist, t_obs, n_step,
+def snr_circ_evolving(m_1, m_2, f_orb_i, dist, t_obs, n_step, t_merge=None,
                       interpolated_g=None, interpolated_sc=None,
                       instrument="LISA", custom_psd=None):
     """Computes SNR for circular and stationary sources
@@ -191,6 +191,9 @@ def snr_circ_evolving(m_1, m_2, f_orb_i, dist, t_obs, n_step,
 
     n_step : `int`
         Number of time steps during observation duration
+
+    t_merge : `float/array`
+        Time until merger
 
     interpolated_g : `function`
         A function returned by :class:`scipy.interpolate.interp2d` that
@@ -258,8 +261,9 @@ def snr_circ_evolving(m_1, m_2, f_orb_i, dist, t_obs, n_step,
 
 
 def snr_ecc_evolving(m_1, m_2, f_orb_i, dist, ecc, harmonics_required, t_obs,
-                     n_step, interpolated_g=None, interpolated_sc=None,
-                     n_proc=1, ret_max_snr_harmonic=False, instrument="LISA",
+                     n_step, t_merge=None, interpolated_g=None,
+                     interpolated_sc=None, n_proc=1,
+                     ret_max_snr_harmonic=False, instrument="LISA",
                      custom_psd=None):
     """Computes SNR for eccentric and evolving sources.
 
@@ -291,6 +295,9 @@ def snr_ecc_evolving(m_1, m_2, f_orb_i, dist, ecc, harmonics_required, t_obs,
 
     n_step : `int`
         Number of time steps during observation duration
+
+    t_merge : `float/array`
+        Time until merger
 
     interpolated_g : `function`
         A function returned by :class:`scipy.interpolate.interp2d` that
@@ -331,9 +338,11 @@ def snr_ecc_evolving(m_1, m_2, f_orb_i, dist, ecc, harmonics_required, t_obs,
         ``ret_max_snr_harmonic=True``)
     """
     m_c = utils.chirp_mass(m_1=m_1, m_2=m_2)
+
     # calculate minimum of observation time and merger time
-    t_merge = evol.get_t_merge_ecc(m_1=m_1, m_2=m_2,
-                                   f_orb_i=f_orb_i, ecc_i=ecc)
+    if t_merge is None:
+        t_merge = evol.get_t_merge_ecc(m_1=m_1, m_2=m_2,
+                                       f_orb_i=f_orb_i, ecc_i=ecc)
     t_evol = np.minimum(t_merge, t_obs).to(u.s)
 
     # get eccentricity and f_orb evolutions

--- a/legwork/source.py
+++ b/legwork/source.py
@@ -351,7 +351,9 @@ class Source():
         return np.logical_and(circular_mask, stat_mask)
 
     def get_h_0_n(self, harmonics, which_sources=None):
-        """Computes the strain for all binaries for the given ``harmonics``
+        """Computes the strain for binaries for the given ``harmonics``. Use
+        ``which_sources`` to select a subset of the sources. Merged sources
+        are set to have 0.0 strain.
 
         Parameters
         ----------
@@ -369,12 +371,25 @@ class Source():
         """
         if which_sources is None:
             which_sources = np.repeat(True, self.n_sources)
-        return strain.h_0_n(m_c=self.m_c[which_sources],
-                            f_orb=self.f_orb[which_sources],
-                            ecc=self.ecc[which_sources],
-                            n=harmonics,
-                            dist=self.dist[which_sources],
-                            interpolated_g=self.g)[:, 0, :]
+
+        # by default set all strains to zero
+        n_harmonics = len(harmonics) if not isinstance(harmonics, int) else 1
+        h_0_n = np.zeros((self.n_sources, n_harmonics))
+
+        # find a mask for the inspiralling sources (exclude merged)
+        insp_sources = np.logical_and(np.logical_not(self.merged),
+                                      which_sources)
+
+        # calculate strain for these values
+        h_0_n[insp_sources, :] = strain.h_0_n(m_c=self.m_c[insp_sources],
+                                              f_orb=self.f_orb[insp_sources],
+                                              ecc=self.ecc[insp_sources],
+                                              n=harmonics,
+                                              dist=self.dist[insp_sources],
+                                              interpolated_g=self.g)[:, 0, :]
+
+        # return all sources, not just inpsiralling ones
+        return h_0_n[which_sources, :]
 
     def get_h_c_n(self, harmonics, which_sources=None):
         """Computes the characteristic strain for all binaries

--- a/legwork/source.py
+++ b/legwork/source.py
@@ -721,9 +721,9 @@ class Source():
         insp = np.logical_and(which_sources,
                               np.logical_not(self.merged))
         t_merge[insp] = evol.get_t_merge_ecc(ecc_i=self.ecc[insp],
-                                                  f_orb_i=self.f_orb[insp],
-                                                m_1=self.m_1[insp],
-                                                m_2=self.m_2[insp])
+                                             f_orb_i=self.f_orb[insp],
+                                             m_1=self.m_1[insp],
+                                             m_2=self.m_2[insp])
         if save_in_class:
             self.t_merge = t_merge
 

--- a/legwork/source.py
+++ b/legwork/source.py
@@ -76,7 +76,7 @@ class Source():
 
     ecc_tol : `float`
         Eccentricity above which a binary is considered eccentric. Set by
-        :meth:`legwork.source.Source.fe_maskentric_transition`
+        :meth:`legwork.source.Source.find_eccentric_transition`
 
     snr : `float/array`
         Signal-to-noise ratio. Set by :meth:`legwork.source.Source.get_snr`
@@ -214,7 +214,7 @@ class Source():
 
         self.max_strain_harmonic = max_strain_harmonic
 
-    def fe_maskentric_transition(self):
+    def find_eccentric_transition(self):
         """Find the eccentricity at which we must treat binaries at eccentric.
         We define this as the maximum eccentricity at which the n=2 harmonic
         is the total GW luminosity given the tolerance ``self._gw_lum_tol``.
@@ -238,7 +238,7 @@ class Source():
         """
         self._gw_lum_tol = gw_lum_tol
         self.create_harmonics_functions()
-        self.fe_maskentric_transition()
+        self.find_eccentric_transition()
 
     def set_g(self, interpolate_g):
         """Set Source g function if user wants to interpolate g(n,e).

--- a/legwork/source.py
+++ b/legwork/source.py
@@ -537,9 +537,12 @@ class Source():
         """
         if which_sources is None:
             which_sources = np.repeat(True, self.n_sources)
+
+        insp_sources = np.logical_and(which_sources,
+                                      np.logical_not(self.merged))
         snr = np.zeros(self.n_sources)
-        ind_ecc = np.logical_and(self.ecc > self.ecc_tol, which_sources)
-        ind_circ = np.logical_and(self.ecc <= self.ecc_tol, which_sources)
+        ind_ecc = np.logical_and(self.ecc > self.ecc_tol, insp_sources)
+        ind_circ = np.logical_and(self.ecc <= self.ecc_tol, insp_sources)
 
         # default to n = 2 for max snr harmonic
         msh = np.repeat(2, self.n_sources)
@@ -583,11 +586,11 @@ class Source():
 
         if self.max_snr_harmonic is None:
             self.max_snr_harmonic = np.zeros(self.n_sources).astype(int)
-        self.max_snr_harmonic[which_sources] = msh[which_sources]
+        self.max_snr_harmonic[insp_sources] = msh[insp_sources]
 
         if self.snr is None:
             self.snr = np.zeros(self.n_sources)
-        self.snr[which_sources] = snr[which_sources]
+        self.snr[insp_sources] = snr[insp_sources]
 
         return snr[which_sources]
 

--- a/legwork/source.py
+++ b/legwork/source.py
@@ -796,7 +796,7 @@ class Source():
             f_orb_evol[e_mask] = evolution[1][:, -1]
 
         # record which sources merged during evolution
-        merged = np.logical_and(ecc_evol == 0.0, f_orb_evol == 1 * u.Hz)
+        merged = np.logical_and(ecc_evol == 0.0, f_orb_evol == 1e2* u.Hz)
 
         if create_new_class:
             # create new source with same attributes (but evolved ecc/f_orb)

--- a/legwork/source.py
+++ b/legwork/source.py
@@ -812,6 +812,12 @@ class Source():
             evolved_sources.interpolate_sc = True
             evolved_sources.sc = self.sc
 
+            if self.t_merge is not None:
+                evolved_sources.t_merge = np.maximum(0 * u.Gyr,
+                                                     self.t_merge - t_evol)
+            else:
+                evolved_sources.t_merge = None
+
             # record which sources have merged
             evolved_sources.merged = merged
 
@@ -822,6 +828,9 @@ class Source():
             self.ecc = ecc_evol
             self.f_orb = f_orb_evol
             self.merged = merged
+
+            if self.t_merge is not None:
+                self.t_merge = np.maximum(0 * u.Gyr, self.t_merge - t_evol)
 
     def plot_source_variables(self, xstr, ystr=None, which_sources=None,
                               **kwargs):  # pragma: no cover

--- a/legwork/source.py
+++ b/legwork/source.py
@@ -759,7 +759,7 @@ class Source():
         e_mask = np.logical_not(c_mask)
 
         # split up the evolution times if need be
-        if isinstance(t_evol, u.quantity.Quantity):
+        if isinstance(t_evol.value, (int, float)):
             t_evol_circ = t_evol
             t_evol_ecc = t_evol
         else:
@@ -773,12 +773,13 @@ class Source():
 
         # calculate the evolved values for circular binaries
         if c_mask.any():
-            f_orb_evol[c_mask] = evol.evol_circ(t_evol=t_evol_circ,
-                                                n_step=n_step,
-                                                m_1=self.m_1[c_mask],
-                                                m_2=self.m_2[c_mask],
-                                                f_orb_i=self.f_orb[c_mask],
-                                                output_vars="f_orb")[:, -1]
+            evolution = evol.evol_circ(t_evol=t_evol_circ,
+                                       n_step=n_step,
+                                       m_1=self.m_1[c_mask],
+                                       m_2=self.m_2[c_mask],
+                                       f_orb_i=self.f_orb[c_mask],
+                                       output_vars="f_orb")
+            f_orb_evol[c_mask] = evolution[:, -1]
 
         # calculate the evolved values for eccentric binaries
         if e_mask.any():
@@ -811,12 +812,11 @@ class Source():
             evolved_sources.g = self.g
             evolved_sources.interpolate_sc = True
             evolved_sources.sc = self.sc
+            evolved_sources.t_merge = None
 
             if self.t_merge is not None:
                 evolved_sources.t_merge = np.maximum(0 * u.Gyr,
                                                      self.t_merge - t_evol)
-            else:
-                evolved_sources.t_merge = None
 
             # record which sources have merged
             evolved_sources.merged = merged

--- a/legwork/source.py
+++ b/legwork/source.py
@@ -630,8 +630,11 @@ class Source():
 
         if which_sources is None:
             which_sources = np.repeat(True, self.n_sources)
-        ind_ecc = np.logical_and(self.ecc > self.ecc_tol, which_sources)
-        ind_circ = np.logical_and(self.ecc <= self.ecc_tol, which_sources)
+
+        insp_sources = np.logical_and(which_sources,
+                                      np.logical_not(self.merged))
+        ind_ecc = np.logical_and(self.ecc > self.ecc_tol, insp_sources)
+        ind_circ = np.logical_and(self.ecc <= self.ecc_tol, insp_sources)
 
         # default to n = 2 for max snr harmonic
         msh = np.repeat(2, self.n_sources)
@@ -679,11 +682,11 @@ class Source():
 
         if self.max_snr_harmonic is None:
             self.max_snr_harmonic = np.zeros(self.n_sources).astype(int)
-        self.max_snr_harmonic[which_sources] = msh[which_sources]
+        self.max_snr_harmonic[insp_sources] = msh[insp_sources]
 
         if self.snr is None:
             self.snr = np.zeros(self.n_sources)
-        self.snr[which_sources] = snr[which_sources]
+        self.snr[insp_sources] = snr[insp_sources]
 
         return snr[which_sources]
 

--- a/legwork/source.py
+++ b/legwork/source.py
@@ -4,7 +4,7 @@ import numpy as np
 from importlib import resources
 from scipy.interpolate import interp1d, interp2d
 
-from legwork import utils, strain, psd
+from legwork import utils, strain, psd, evol
 import legwork.snr as sn
 import legwork.visualisation as vis
 
@@ -141,6 +141,8 @@ class Source():
         self.n_sources = len(m_1)
         self.interpolate_sc = interpolate_sc
         self._sc_params = sc_params
+
+        self.merged = np.repeat(False, self.n_sources)
 
         self.update_gw_lum_tol(gw_lum_tol)
         self.set_g(interpolate_g)
@@ -430,15 +432,22 @@ class Source():
         SNR : `array`
             The signal-to-noise ratio
         """
-        if self._sc_params is not None:     # pragma: no cover
-            sc_t_obs = t_obs
+        # if the user interpolated a sensitivity curve
+        if self.interpolate_sc and (self._sc_params
+                                    is not None):     # pragma: no cover
             if "t_obs" in self._sc_params.keys():
                 sc_t_obs = self._sc_params["t_obs"]
+            else:
+                # default is 4 years if none passed
+                sc_t_obs = 4 * u.yr
+
+            # make sure the observation time matches
             if t_obs != sc_t_obs:
                 print("Warning: Current `sc_params` uses t_obs =",
                       "{} but this function".format(self._sc_params["t_obs"]),
                       "was passed t_obs = {}. Update your".format(t_obs),
-                      "sc_params to match with Source.update_sc_params()!")
+                      "sc_params with Source.update_sc_params() to make sure",
+                      "your interpolated curve matches!")
 
         if verbose:
             print("Calculating SNR for {} sources".format(self.n_sources))
@@ -645,6 +654,95 @@ class Source():
         self.snr[which_sources] = snr[which_sources]
 
         return snr[which_sources]
+
+    def evolve_sources(self, t_evol, create_new_class=False):
+        """Evolve sources forward in time for ``t_evol`` amount of time. If
+        ``create_new_class`` is ``True`` then save the updated sources in a new
+        Source class, otherwise, update the values in this class.
+
+        Parameters
+        ----------
+        t_evol : `float/array`
+            Amount of time to evolve sources. Either a single value for all
+            sources or an array of values corresponding to each source.
+        create_new_class : bool, optional
+            Whether to save the evolved binaries in a new class or not. If not
+            simply update the current class, by default False.
+
+        Returns
+        -------
+        evolved_sources : `Source`
+            The new class with evolved sources, only returned if
+            ``create_new_class`` is ``True``.
+        """
+        # separate out the exactly circular sources from eccentric ones
+        c_mask = self.ecc == 0.0
+        e_mask = np.logical_not(c_mask)
+
+        # split up the evolution times if need be
+        if isinstance(t_evol, u.quantity.Quantity):
+            t_evol_circ = t_evol
+            t_evol_ecc = t_evol
+        else:
+            t_evol_circ = t_evol[c_mask]
+            t_evol_ecc = t_evol[e_mask]
+
+        # set up the evolved eccentricity and frequency arrays
+        n_step = 2
+        ecc_evol = np.zeros(self.n_sources)
+        f_orb_evol = np.zeros(self.n_sources) * u.Hz
+
+        # calculate the evolved values for circular binaries
+        if c_mask.any():
+            f_orb_evol[c_mask] = evol.evol_circ(t_evol=t_evol_circ,
+                                                n_step=n_step,
+                                                m_1=self.m_1[c_mask],
+                                                m_2=self.m_2[c_mask],
+                                                f_orb_i=self.f_orb[c_mask],
+                                                output_vars="f_orb")[:, -1]
+
+        # calculate the evolved values for eccentric binaries
+        if e_mask.any():
+            evolution = evol.evol_ecc(t_evol=t_evol_ecc,
+                                      n_step=n_step,
+                                      m_1=self.m_1[e_mask],
+                                      m_2=self.m_2[e_mask],
+                                      f_orb_i=self.f_orb[e_mask],
+                                      ecc_i=self.ecc[e_mask],
+                                      output_vars=["ecc", "f_orb"])
+
+            # drop everything except the final evolved value
+            ecc_evol[e_mask] = evolution[0][:, -1]
+            f_orb_evol[e_mask] = evolution[1][:, -1]
+
+        # record which sources merged during evolution
+        merged = np.logical_and(ecc_evol == 0.0, f_orb_evol == 1 * u.Hz)
+
+        if create_new_class:
+            # create new source with same attributes (but evolved ecc/f_orb)
+            evolved_sources = Source(m_1=self.m_1, m_2=self.m_2, ecc=ecc_evol,
+                                     dist=self.dist, n_proc=self.n_proc,
+                                     f_orb=f_orb_evol,
+                                     gw_lum_tol=self._gw_lum_tol,
+                                     stat_tol=self.stat_tol,
+                                     interpolate_g=False, interpolate_sc=False,
+                                     sc_params=self._sc_params)
+
+            # copy over interpolated g and sc
+            evolved_sources.g = self.g
+            evolved_sources.interpolate_sc = True
+            evolved_sources.sc = self.sc
+
+            # record which sources have merged
+            evolved_sources.merged = merged
+
+            # return the new source class
+            return evolved_sources
+        else:
+            # otherwise just update the existing class with evolution
+            self.ecc = ecc_evol
+            self.f_orb = f_orb_evol
+            self.merged = merged
 
     def plot_source_variables(self, xstr, ystr=None, which_sources=None,
                               **kwargs):  # pragma: no cover

--- a/legwork/source.py
+++ b/legwork/source.py
@@ -712,17 +712,23 @@ class Source():
         t_merge : `float/array`
             Merger times
         """
+        # if no subset or saving times, select all sources
         if save_in_class or which_sources is None:
             which_sources = np.repeat(True, self.n_sources)
+        t_merge = np.zeros(len(which_sources)) * u.Gyr
 
-        t_merge = evol.get_t_merge_ecc(ecc_i=self.ecc[which_sources],
-                                       f_orb_i=self.f_orb[which_sources],
-                                       m_1=self.m_1[which_sources],
-                                       m_2=self.m_2[which_sources])
-
+        # only compute merger times for inspiralling binaries
+        insp = np.logical_and(which_sources,
+                              np.logical_not(self.merged))
+        t_merge[insp] = evol.get_t_merge_ecc(ecc_i=self.ecc[insp],
+                                                  f_orb_i=self.f_orb[insp],
+                                                m_1=self.m_1[insp],
+                                                m_2=self.m_2[insp])
         if save_in_class:
             self.t_merge = t_merge
-        return t_merge
+
+        # only return subset of sources
+        return t_merge[which_sources]
 
     def evolve_sources(self, t_evol, create_new_class=False):
         """Evolve sources forward in time for ``t_evol`` amount of time. If

--- a/legwork/source.py
+++ b/legwork/source.py
@@ -136,6 +136,7 @@ class Source():
         self.f_orb = f_orb
         self.a = a
         self.n_proc = n_proc
+        self.t_merge = None
         self.snr = None
         self.max_snr_harmonic = None
         self.n_sources = len(m_1)
@@ -689,6 +690,39 @@ class Source():
         self.snr[insp_sources] = snr[insp_sources]
 
         return snr[which_sources]
+
+    def get_merger_time(self, save_in_class=True, which_sources=None):
+        """Get the merger time for each source. Set ``save_in_class`` to true
+        to save the values as an instance variable in the class. Use
+        ``which_sources`` to select a subset of the sources in the class. Note
+        that if ``save_in_class`` is set to ``True``, ``which_sources`` will be
+        ignored.
+
+        Parameters
+        ----------
+        save_in_class : `bool`, optional
+            Whether the save the result into the class as an instance variable,
+            by default True
+        which_sources : `bool/array`, optional
+            A mask for the subset of sources for which to calculate the merger
+            time, by default all sources (None)
+
+        Returns
+        -------
+        t_merge : `float/array`
+            Merger times
+        """
+        if save_in_class or which_sources is None:
+            which_sources = np.repeat(True, self.n_sources)
+
+        t_merge = evol.get_t_merge_ecc(ecc_i=self.ecc[which_sources],
+                                       f_orb_i=self.f_orb[which_sources],
+                                       m_1=self.m_1[which_sources],
+                                       m_2=self.m_2[which_sources])
+
+        if save_in_class:
+            self.t_merge = t_merge
+        return t_merge
 
     def evolve_sources(self, t_evol, create_new_class=False):
         """Evolve sources forward in time for ``t_evol`` amount of time. If

--- a/legwork/tests/test_snrs.py
+++ b/legwork/tests/test_snrs.py
@@ -26,9 +26,10 @@ class Test(unittest.TestCase):
                                          harmonics_required=3)
         self.assertTrue(np.allclose(snr_circ, snr_ecc))
 
-    def test_stat_vs_evol_eccentric(self):
+    def test_stat_vs_evol_eccentric_and_harmonics(self):
         """check whether the evolving snr equation gives the same results
-        as the stationary one for eccentric stationary binaries"""
+        as the stationary one for eccentric stationary binaries. Also whether
+        the individual harmonics are done properly"""
         n_values = 100
         m_1 = np.random.uniform(0, 10, n_values) * u.Msun
         m_2 = np.random.uniform(0, 10, n_values) * u.Msun
@@ -44,5 +45,17 @@ class Test(unittest.TestCase):
         snr_ecc = snr.snr_ecc_evolving(m_1=m_1, m_2=m_2, ecc=ecc,
                                        f_orb_i=f_orb, dist=dist, n_step=100,
                                        t_obs=t_obs, harmonics_required=10)
+
+        snr2_circ_n = snr.snr_ecc_stationary(m_c=m_c, ecc=ecc, f_orb=f_orb,
+                                             dist=dist, t_obs=t_obs,
+                                             harmonics_required=10,
+                                             ret_snr2_by_harmonic=True)
+        snr2_ecc_n = snr.snr_ecc_evolving(m_1=m_1, m_2=m_2, ecc=ecc,
+                                          f_orb_i=f_orb, dist=dist, n_step=100,
+                                          t_obs=t_obs, harmonics_required=10,
+                                          ret_snr2_by_harmonic=True)
+
+        self.assertTrue(np.allclose(snr2_circ_n.sum(axis=1)**(0.5), snr_circ))
+        self.assertTrue(np.allclose(snr2_ecc_n.sum(axis=1)**(0.5), snr_ecc))
 
         self.assertTrue(np.allclose(snr_circ, snr_ecc, atol=1e-1, rtol=1e-2))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = legwork
-version = 0.0.2
+version = 0.0.3
 url = https://github.com/katiebreivik/gw-calcs
 author = Tom Wagg, Katie Breivik
 author_email = kbreivik@flatironinstitute.org


### PR DESCRIPTION
I've added ``changelog.md`` for keeping track of what changes in each version and updated the version number.

This also makes it easy for me because now I can copy directly from that into here :D
- Allow the computation of merger times with ``get_merger_times``
    - After computing, times are used automatically
    in subsequent SNR calculations to avoid doubling up the computation
- Add ``evolve_sources`` function that evolves sources through time, updates merger times and if necessary marks them as merged
    - Merged sources are ignored in other computations (e.g. strain and SNR)
- Add ``ret_snr2_by_harmonic`` to eccentric snr functions to allow the user to get the SNR at each harmonic separately instead of the total
- Added a fix to the SNR for circular binaries where the last timestep sometimes got messed up by just subtracting a second!